### PR TITLE
Change RTCIceConnectionState to crate's IceConnectionState

### DIFF
--- a/native/specter_nif/src/atoms.rs
+++ b/native/specter_nif/src/atoms.rs
@@ -25,6 +25,7 @@ rustler::atoms! {
     current_remote_description,
     data_channel_created,
     ice_candidate,
+    ice_connection_state,
     local_description,
     peer_connection_closed,
     peer_connection_error,
@@ -37,15 +38,4 @@ rustler::atoms! {
 
     answer,
     offer,
-
-    // ice connection state
-    ice_connection_state,
-    unspecified,
-    new,
-    checking,
-    connected,
-    completed,
-    disconnected,
-    failed,
-    closed,
 }

--- a/native/specter_nif/src/peer_connection/peer_conn_state.rs
+++ b/native/specter_nif/src/peer_connection/peer_conn_state.rs
@@ -1,0 +1,29 @@
+use rustler::NifUnitEnum;
+use webrtc::ice_transport::ice_connection_state::RTCIceConnectionState;
+
+#[derive(NifUnitEnum)]
+pub enum IceConnectionState {
+    Checking,
+    Closed,
+    Completed,
+    Connected,
+    Disconnected,
+    Failed,
+    New,
+    Unspecified,
+}
+
+impl From<&RTCIceConnectionState> for IceConnectionState {
+    fn from(state: &RTCIceConnectionState) -> Self {
+        match state {
+            &RTCIceConnectionState::Checking => IceConnectionState::Checking,
+            &RTCIceConnectionState::Closed => IceConnectionState::Closed,
+            &RTCIceConnectionState::Completed => IceConnectionState::Completed,
+            &RTCIceConnectionState::Connected => IceConnectionState::Connected,
+            &RTCIceConnectionState::Disconnected => IceConnectionState::Disconnected,
+            &RTCIceConnectionState::Failed => IceConnectionState::Failed,
+            &RTCIceConnectionState::New => IceConnectionState::New,
+            &RTCIceConnectionState::Unspecified => IceConnectionState::Unspecified,
+        }
+    }
+}


### PR DESCRIPTION
This allows us to use NifUnitEnum to encode atoms transmitted back to Elixir, and also allows to compiler to catch missing branches.

One thing that this implementation caught was that `Disconnected` was missing from the list, making me consider this a good pattern going forward in spite of the extra thing on the stack.